### PR TITLE
fix: actions release go version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ jobs:
   Release:
     runs-on: ubuntu-latest
     env:
+      GO_VERSION: "1.21"
       GOPRIVATE: gitlab.com/nitrado/*
 
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/nitrado/terraform-provider-ec
 
-go 1.21
+go 1.21.1
+
+toolchain go1.21.3
 
 require (
 	github.com/ettle/strcase v0.1.1


### PR DESCRIPTION
This PR sets the GitHub Actions release Go version properly.