### PR TITLE
fix: bump tfconv to fix panic

### DIFF
--- a/ec/armada/resource_armadaset_test.go
+++ b/ec/armada/resource_armadaset_test.go
@@ -40,6 +40,8 @@ func TestResourceArmadaSets(t *testing.T) {
 					resource.TestCheckResourceAttr("ec_armada_armadaset.test", "spec.0.template.0.spec.0.containers.0.name", "my-ctr"),
 					resource.TestCheckResourceAttr("ec_armada_armadaset.test", "spec.0.template.0.spec.0.containers.0.branch", "prod"),
 					resource.TestCheckResourceAttr("ec_armada_armadaset.test", "spec.0.template.0.spec.0.containers.0.image", "test-xyz"),
+					resource.TestCheckResourceAttr("ec_armada_armadaset.test", "spec.0.template.0.spec.0.containers.0.command.#", "1"),
+					resource.TestCheckResourceAttr("ec_armada_armadaset.test", "spec.0.template.0.spec.0.containers.0.command.0", ""),
 				),
 			},
 			{
@@ -104,6 +106,9 @@ func testResourceArmadaSetsConfigBasic(env, name string) string {
           name = "my-ctr"
           branch = "prod"
           image = "test-xyz"
+          command = [
+		    ""
+          ]
         }
       }
     }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.19.4
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
-	github.com/nitrado/tfconv v1.2.1
+	github.com/nitrado/tfconv v1.2.2
 	github.com/stretchr/testify v1.9.0
 	gitlab.com/nitrado/b2b/ec/apicore v1.3.0
 	gitlab.com/nitrado/b2b/ec/core v0.16.1

--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/nitrado/tfconv v1.2.1 h1:Gw/IYKGJErfr/CMUbkdfGihilJoUqIGxsBDGS3xPsw4=
-github.com/nitrado/tfconv v1.2.1/go.mod h1:cTIaCT39qOzH56m3EbwiV39sDqNAXnL0S/SjdubaSjY=
+github.com/nitrado/tfconv v1.2.2 h1:0LF9OZ5h+osRwbBq5AUZtY1T+VUUUt32niMBECAcaME=
+github.com/nitrado/tfconv v1.2.2/go.mod h1:cTIaCT39qOzH56m3EbwiV39sDqNAXnL0S/SjdubaSjY=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=


### PR DESCRIPTION
## What does it do

This bumps tfconv to fix a panic where Terraform transforms `[""]` into `[nil]`.