### PR TITLE
fix: treat IntOrString as a string field

### DIFF
--- a/docs/data-sources/armada_armada.md
+++ b/docs/data-sources/armada_armada.md
@@ -448,21 +448,17 @@ Optional:
 <a id="nestedblock--spec--template--spec--strategy--rolling_update--max_surge"></a>
 ### Nested Schema for `spec.template.spec.strategy.rolling_update.max_surge`
 
-Optional:
+Required:
 
-- `int_val` (Number)
-- `str_val` (String)
-- `type` (Number)
+- `value` (String)
 
 
 <a id="nestedblock--spec--template--spec--strategy--rolling_update--max_unavailable"></a>
 ### Nested Schema for `spec.template.spec.strategy.rolling_update.max_unavailable`
 
-Optional:
+Required:
 
-- `int_val` (Number)
-- `str_val` (String)
-- `type` (Number)
+- `value` (String)
 
 
 

--- a/docs/data-sources/armada_armada_v1.md
+++ b/docs/data-sources/armada_armada_v1.md
@@ -448,21 +448,17 @@ Optional:
 <a id="nestedblock--spec--template--spec--strategy--rolling_update--max_surge"></a>
 ### Nested Schema for `spec.template.spec.strategy.rolling_update.max_surge`
 
-Optional:
+Required:
 
-- `int_val` (Number)
-- `str_val` (String)
-- `type` (Number)
+- `value` (String)
 
 
 <a id="nestedblock--spec--template--spec--strategy--rolling_update--max_unavailable"></a>
 ### Nested Schema for `spec.template.spec.strategy.rolling_update.max_unavailable`
 
-Optional:
+Required:
 
-- `int_val` (Number)
-- `str_val` (String)
-- `type` (Number)
+- `value` (String)
 
 
 

--- a/docs/data-sources/armada_armadaset.md
+++ b/docs/data-sources/armada_armadaset.md
@@ -462,21 +462,17 @@ Optional:
 <a id="nestedblock--spec--template--spec--strategy--rolling_update--max_surge"></a>
 ### Nested Schema for `spec.template.spec.strategy.rolling_update.max_surge`
 
-Optional:
+Required:
 
-- `int_val` (Number)
-- `str_val` (String)
-- `type` (Number)
+- `value` (String)
 
 
 <a id="nestedblock--spec--template--spec--strategy--rolling_update--max_unavailable"></a>
 ### Nested Schema for `spec.template.spec.strategy.rolling_update.max_unavailable`
 
-Optional:
+Required:
 
-- `int_val` (Number)
-- `str_val` (String)
-- `type` (Number)
+- `value` (String)
 
 
 

--- a/docs/data-sources/armada_armadaset_v1.md
+++ b/docs/data-sources/armada_armadaset_v1.md
@@ -462,21 +462,17 @@ Optional:
 <a id="nestedblock--spec--template--spec--strategy--rolling_update--max_surge"></a>
 ### Nested Schema for `spec.template.spec.strategy.rolling_update.max_surge`
 
-Optional:
+Required:
 
-- `int_val` (Number)
-- `str_val` (String)
-- `type` (Number)
+- `value` (String)
 
 
 <a id="nestedblock--spec--template--spec--strategy--rolling_update--max_unavailable"></a>
 ### Nested Schema for `spec.template.spec.strategy.rolling_update.max_unavailable`
 
-Optional:
+Required:
 
-- `int_val` (Number)
-- `str_val` (String)
-- `type` (Number)
+- `value` (String)
 
 
 

--- a/docs/resources/armada_armada.md
+++ b/docs/resources/armada_armada.md
@@ -448,21 +448,17 @@ Optional:
 <a id="nestedblock--spec--template--spec--strategy--rolling_update--max_surge"></a>
 ### Nested Schema for `spec.template.spec.strategy.rolling_update.max_surge`
 
-Optional:
+Required:
 
-- `int_val` (Number)
-- `str_val` (String)
-- `type` (Number)
+- `value` (String)
 
 
 <a id="nestedblock--spec--template--spec--strategy--rolling_update--max_unavailable"></a>
 ### Nested Schema for `spec.template.spec.strategy.rolling_update.max_unavailable`
 
-Optional:
+Required:
 
-- `int_val` (Number)
-- `str_val` (String)
-- `type` (Number)
+- `value` (String)
 
 
 

--- a/docs/resources/armada_armada_v1.md
+++ b/docs/resources/armada_armada_v1.md
@@ -448,21 +448,17 @@ Optional:
 <a id="nestedblock--spec--template--spec--strategy--rolling_update--max_surge"></a>
 ### Nested Schema for `spec.template.spec.strategy.rolling_update.max_surge`
 
-Optional:
+Required:
 
-- `int_val` (Number)
-- `str_val` (String)
-- `type` (Number)
+- `value` (String)
 
 
 <a id="nestedblock--spec--template--spec--strategy--rolling_update--max_unavailable"></a>
 ### Nested Schema for `spec.template.spec.strategy.rolling_update.max_unavailable`
 
-Optional:
+Required:
 
-- `int_val` (Number)
-- `str_val` (String)
-- `type` (Number)
+- `value` (String)
 
 
 

--- a/docs/resources/armada_armadaset.md
+++ b/docs/resources/armada_armadaset.md
@@ -462,21 +462,17 @@ Optional:
 <a id="nestedblock--spec--template--spec--strategy--rolling_update--max_surge"></a>
 ### Nested Schema for `spec.template.spec.strategy.rolling_update.max_surge`
 
-Optional:
+Required:
 
-- `int_val` (Number)
-- `str_val` (String)
-- `type` (Number)
+- `value` (String)
 
 
 <a id="nestedblock--spec--template--spec--strategy--rolling_update--max_unavailable"></a>
 ### Nested Schema for `spec.template.spec.strategy.rolling_update.max_unavailable`
 
-Optional:
+Required:
 
-- `int_val` (Number)
-- `str_val` (String)
-- `type` (Number)
+- `value` (String)
 
 
 

--- a/docs/resources/armada_armadaset_v1.md
+++ b/docs/resources/armada_armadaset_v1.md
@@ -462,21 +462,17 @@ Optional:
 <a id="nestedblock--spec--template--spec--strategy--rolling_update--max_surge"></a>
 ### Nested Schema for `spec.template.spec.strategy.rolling_update.max_surge`
 
-Optional:
+Required:
 
-- `int_val` (Number)
-- `str_val` (String)
-- `type` (Number)
+- `value` (String)
 
 
 <a id="nestedblock--spec--template--spec--strategy--rolling_update--max_unavailable"></a>
 ### Nested Schema for `spec.template.spec.strategy.rolling_update.max_unavailable`
 
-Optional:
+Required:
 
-- `int_val` (Number)
-- `str_val` (String)
-- `type` (Number)
+- `value` (String)
 
 
 

--- a/ec/armada/resource_armada_test.go
+++ b/ec/armada/resource_armada_test.go
@@ -37,6 +37,9 @@ func TestResourceArmadas(t *testing.T) {
 					resource.TestCheckResourceAttr("ec_armada_armada.test", "spec.0.distribution.0.max_replicas", "2"),
 					resource.TestCheckResourceAttr("ec_armada_armada.test", "spec.0.distribution.0.buffer_size", "3"),
 					resource.TestCheckResourceAttr("ec_armada_armada.test", "spec.0.template.0.metadata.0.labels.foo", "bar"),
+					resource.TestCheckResourceAttr("ec_armada_armada.test", "spec.0.template.0.spec.0.strategy.0.type", "RollingUpdate"),
+					resource.TestCheckResourceAttr("ec_armada_armada.test", "spec.0.template.0.spec.0.strategy.0.rolling_update.0.max_unavailable.0.value", "25%"),
+					resource.TestCheckResourceAttr("ec_armada_armada.test", "spec.0.template.0.spec.0.strategy.0.rolling_update.0.max_surge.0.value", "10"),
 					resource.TestCheckResourceAttr("ec_armada_armada.test", "spec.0.template.0.spec.0.containers.0.name", "my-ctr"),
 					resource.TestCheckResourceAttr("ec_armada_armada.test", "spec.0.template.0.spec.0.containers.0.branch", "prod"),
 					resource.TestCheckResourceAttr("ec_armada_armada.test", "spec.0.template.0.spec.0.containers.0.image", "test-xyz"),
@@ -97,6 +100,17 @@ func testResourceArmadasConfigBasic(env, name string) string {
         }
       }
       spec {
+		strategy {
+		  type = "RollingUpdate"
+		  rolling_update {
+			max_unavailable {
+			  value = "25%%"
+			}
+			max_surge {	
+			  value = "10"
+			}
+		  }
+		}
         containers {
           name = "my-ctr"
           branch = "prod"

--- a/ec/armada/schema_armada.go
+++ b/ec/armada/schema_armada.go
@@ -618,17 +618,9 @@ func armadaSchema() map[string]*schema.Schema {
 																		MaxItems: 1,
 																		Elem: &schema.Resource{
 																			Schema: map[string]*schema.Schema{
-																				"int_val": {
-																					Type:     schema.TypeInt,
-																					Optional: true,
-																				},
-																				"str_val": {
+																				"value": {
 																					Type:     schema.TypeString,
-																					Optional: true,
-																				},
-																				"type": {
-																					Type:     schema.TypeInt,
-																					Optional: true,
+																					Required: true,
 																				},
 																			},
 																		},
@@ -639,17 +631,9 @@ func armadaSchema() map[string]*schema.Schema {
 																		MaxItems: 1,
 																		Elem: &schema.Resource{
 																			Schema: map[string]*schema.Schema{
-																				"int_val": {
-																					Type:     schema.TypeInt,
-																					Optional: true,
-																				},
-																				"str_val": {
+																				"value": {
 																					Type:     schema.TypeString,
-																					Optional: true,
-																				},
-																				"type": {
-																					Type:     schema.TypeInt,
-																					Optional: true,
+																					Required: true,
 																				},
 																			},
 																		},

--- a/ec/armada/schema_armadaset.go
+++ b/ec/armada/schema_armadaset.go
@@ -668,17 +668,9 @@ func armadaSetSchema() map[string]*schema.Schema {
 																		MaxItems: 1,
 																		Elem: &schema.Resource{
 																			Schema: map[string]*schema.Schema{
-																				"int_val": {
-																					Type:     schema.TypeInt,
-																					Optional: true,
-																				},
-																				"str_val": {
+																				"value": {
 																					Type:     schema.TypeString,
-																					Optional: true,
-																				},
-																				"type": {
-																					Type:     schema.TypeInt,
-																					Optional: true,
+																					Required: true,
 																				},
 																			},
 																		},
@@ -689,17 +681,9 @@ func armadaSetSchema() map[string]*schema.Schema {
 																		MaxItems: 1,
 																		Elem: &schema.Resource{
 																			Schema: map[string]*schema.Schema{
-																				"int_val": {
-																					Type:     schema.TypeInt,
-																					Optional: true,
-																				},
-																				"str_val": {
+																				"value": {
 																					Type:     schema.TypeString,
-																					Optional: true,
-																				},
-																				"type": {
-																					Type:     schema.TypeInt,
-																					Optional: true,
+																					Required: true,
 																				},
 																			},
 																		},

--- a/ec/ec.go
+++ b/ec/ec.go
@@ -15,6 +15,7 @@ import (
 	clientsettools "github.com/gamefabric/gf-core/pkg/apiclient/tools/clientset"
 	"github.com/nitrado/tfconv"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // ProviderContext contains connection context information.
@@ -100,6 +101,7 @@ func WaitForDeletion[T runtime.Object](ctx context.Context, getter clientsettool
 func Converter() *tfconv.Converter {
 	c := tfconv.NewWithName(FieldName, "json")
 	c.Register(resource.Quantity{}, expandQuantity, flattenQuantity)
+	c.Register(intstr.IntOrString{}, expandIntOrString, flattenIntOrString)
 	return c
 }
 
@@ -110,6 +112,15 @@ func expandQuantity(v any) (any, error) {
 func flattenQuantity(v any) (any, error) {
 	q := v.(resource.Quantity)
 	return (&q).String(), nil
+}
+
+func expandIntOrString(v any) (any, error) {
+	return intstr.Parse(v.(string)), nil
+}
+
+func flattenIntOrString(v any) (any, error) {
+	i := v.(intstr.IntOrString)
+	return i.String(), nil
 }
 
 // FieldName returns the terraform-styled field name from the given name.

--- a/internal/cmd/schema-gen/gen.go
+++ b/internal/cmd/schema-gen/gen.go
@@ -135,7 +135,7 @@ func (g *Generator) customize(obj any, sf *reflect.StructField, typ reflect.Type
 	}
 
 	switch typ.String() {
-	case "resource.Quantity":
+	case "resource.Quantity", "intstr.IntOrString":
 		return "", reflect.String, true
 	case "v1.ObjectMeta":
 		return "meta.Schema", kind, true


### PR DESCRIPTION
## Goal of this PR

This fixes an issue where `intstr.IntOrString` is very difficult to use. Instead it is made a string, and parsed internally.

## How did I test it?

Unit tests
