### PR TITLE
chore!: remove deprecated ArmadaSet field .Spec.Armadas[].Name & .Spec.Override[].Name (GF-544)

### DIFF
--- a/docs/data-sources/armada_armadaset.md
+++ b/docs/data-sources/armada_armadaset.md
@@ -66,7 +66,6 @@ Required:
 Optional:
 
 - `description` (String) Description is the optional description of the armada.
-- `name` (String) Name is the name of the armada. Deprecated: In future releases, the Armada name will be based on the Region.
 
 <a id="nestedblock--spec--armadas--distribution"></a>
 ### Nested Schema for `spec.armadas.distribution`
@@ -535,7 +534,6 @@ Optional:
 
 - `env` (Block List) Env is a list of environment variables to set on containers. (see [below for nested schema](#nestedblock--spec--override--env))
 - `labels` (Map of String) Labels is a map of keys and values that can be used to organize and categorize objects.
-- `name` (String) Name is the name of the armada Region that will be overridden. Deprecated: Use the Region to override values.
 
 <a id="nestedblock--spec--override--env"></a>
 ### Nested Schema for `spec.override.env`

--- a/docs/data-sources/armada_armadaset_v1.md
+++ b/docs/data-sources/armada_armadaset_v1.md
@@ -66,7 +66,6 @@ Required:
 Optional:
 
 - `description` (String) Description is the optional description of the armada.
-- `name` (String) Name is the name of the armada. Deprecated: In future releases, the Armada name will be based on the Region.
 
 <a id="nestedblock--spec--armadas--distribution"></a>
 ### Nested Schema for `spec.armadas.distribution`
@@ -535,7 +534,6 @@ Optional:
 
 - `env` (Block List) Env is a list of environment variables to set on containers. (see [below for nested schema](#nestedblock--spec--override--env))
 - `labels` (Map of String) Labels is a map of keys and values that can be used to organize and categorize objects.
-- `name` (String) Name is the name of the armada Region that will be overridden. Deprecated: Use the Region to override values.
 
 <a id="nestedblock--spec--override--env"></a>
 ### Nested Schema for `spec.override.env`

--- a/docs/resources/armada_armadaset.md
+++ b/docs/resources/armada_armadaset.md
@@ -66,7 +66,6 @@ Required:
 Optional:
 
 - `description` (String) Description is the optional description of the armada.
-- `name` (String) Name is the name of the armada. Deprecated: In future releases, the Armada name will be based on the Region.
 
 <a id="nestedblock--spec--armadas--distribution"></a>
 ### Nested Schema for `spec.armadas.distribution`
@@ -535,7 +534,6 @@ Optional:
 
 - `env` (Block List) Env is a list of environment variables to set on containers. (see [below for nested schema](#nestedblock--spec--override--env))
 - `labels` (Map of String) Labels is a map of keys and values that can be used to organize and categorize objects.
-- `name` (String) Name is the name of the armada Region that will be overridden. Deprecated: Use the Region to override values.
 
 <a id="nestedblock--spec--override--env"></a>
 ### Nested Schema for `spec.override.env`

--- a/docs/resources/armada_armadaset_v1.md
+++ b/docs/resources/armada_armadaset_v1.md
@@ -66,7 +66,6 @@ Required:
 Optional:
 
 - `description` (String) Description is the optional description of the armada.
-- `name` (String) Name is the name of the armada. Deprecated: In future releases, the Armada name will be based on the Region.
 
 <a id="nestedblock--spec--armadas--distribution"></a>
 ### Nested Schema for `spec.armadas.distribution`
@@ -535,7 +534,6 @@ Optional:
 
 - `env` (Block List) Env is a list of environment variables to set on containers. (see [below for nested schema](#nestedblock--spec--override--env))
 - `labels` (Map of String) Labels is a map of keys and values that can be used to organize and categorize objects.
-- `name` (String) Name is the name of the armada Region that will be overridden. Deprecated: Use the Region to override values.
 
 <a id="nestedblock--spec--override--env"></a>
 ### Nested Schema for `spec.override.env`

--- a/ec/armada/data_source_armadaset_test.go
+++ b/ec/armada/data_source_armadaset_test.go
@@ -69,7 +69,6 @@ func testDataSourceArmadaSetsConfigBasic(name, env string) string {
   spec {
     description = "My ArmadaSet"
     armadas {
-      name = "eu-armada"
       region = "eu"
       distribution {
         name = "baremetal"

--- a/ec/armada/resource_armadaset_test.go
+++ b/ec/armada/resource_armadaset_test.go
@@ -86,7 +86,6 @@ func testResourceArmadaSetsConfigBasic(env, name string) string {
   spec {
     description = "My ArmadaSet"
     armadas {
-      name = "eu-armada"
       region = "eu"
       distribution {
         name = "baremetal"
@@ -125,7 +124,6 @@ func testResourceArmadaSetsConfigBasicWithEnv(env, name string) string {
   spec {
     description = "My ArmadaSet"
     armadas {
-      name = "eu-armada"
       region = "eu"
       distribution {
         name = "baremetal"

--- a/ec/armada/schema_armadaset.go
+++ b/ec/armada/schema_armadaset.go
@@ -68,11 +68,6 @@ func armadaSetSchema() map[string]*schema.Schema {
 										},
 									},
 								},
-								"name": {
-									Type:        schema.TypeString,
-									Description: "Name is the name of the armada. Deprecated: In future releases, the Armada name will be based on the Region.",
-									Optional:    true,
-								},
 								"region": {
 									Type:        schema.TypeString,
 									Description: "Region defines the region the game servers are distributed to.",
@@ -128,11 +123,6 @@ func armadaSetSchema() map[string]*schema.Schema {
 									Description: "Labels is a map of keys and values that can be used to organize and categorize objects.",
 									Optional:    true,
 									Elem:        &schema.Schema{Type: schema.TypeString},
-								},
-								"name": {
-									Type:        schema.TypeString,
-									Description: "Name is the name of the armada Region that will be overridden. Deprecated: Use the Region to override values.",
-									Optional:    true,
 								},
 								"region": {
 									Type:        schema.TypeString,

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.1
 require (
 	github.com/ettle/strcase v0.2.0
 	github.com/gamefabric/gf-apicore v1.5.0
-	github.com/gamefabric/gf-core v0.23.0-rc.1
+	github.com/gamefabric/gf-core v0.23.0-rc.3.0.20250512122820-f61633e9e797
 	github.com/hashicorp/go-cty v1.4.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
 	github.com/nitrado/tfconv v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/gamefabric/gf-apicore v1.5.0 h1:+sMS0XtN6JDVzx1xf/w+Xy4wjzBcx/qGk5ixx
 github.com/gamefabric/gf-apicore v1.5.0/go.mod h1:P8R8MyhYZ9WC1Zeti8s1DifD9Pcbzo+MBeN/gI1qv0k=
 github.com/gamefabric/gf-core v0.23.0-rc.1 h1:hcEiDHeWzy8wyYLB9ZIdqHG3+wp2mDboiGPiIf1KRG4=
 github.com/gamefabric/gf-core v0.23.0-rc.1/go.mod h1:VgbO6Gly8oFw0iX/gAWIeKyzTOFw9Z3PkJhtg5mchvo=
+github.com/gamefabric/gf-core v0.23.0-rc.3.0.20250512122820-f61633e9e797 h1:/S054vmk/8OfaNZ2E+Fk11tJNYvgVk/7Wt34CLBw7TQ=
+github.com/gamefabric/gf-core v0.23.0-rc.3.0.20250512122820-f61633e9e797/go.mod h1:qaTRrShgluea3rQPy2vk8vVLHKTR5R/0Al0rQ2KqrLA=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
 github.com/go-git/go-billy/v5 v5.6.0 h1:w2hPNtoehvJIxR00Vb4xX94qHQi/ApZfX+nBE2Cjio8=


### PR DESCRIPTION
## Goal of this PR

Remove deprecated ArmadaSet fields `.Spec.Armadas[].Name` & `.Spec.Override[].Name`.

## How did I test it?

Unit tests.