### PR TITLE
feat: bump golangci-lint to v2.1.6

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     env:
       GOPROXY: https://${{ secrets.GOPROXY }},direct
       GONOSUMDB: ${{ secrets.GONOSUMDB }}
-      GOLANGCI_LINT_VERSION: v1.64.7
+      GOLANGCI_LINT_VERSION: v2.1.6
 
     steps:
       - name: Checkout code
@@ -36,7 +36,7 @@ jobs:
         if: steps.install-go.outputs.cache-hit != 'true'
 
       - name: Run linter
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,30 +1,23 @@
+version: "2"
 run:
   tests: false
-  timeout: 5m
 
-linters-settings:
-  cyclop:
-    max-complexity: 15
-    skip-tests: true
-  lll:
-    line-length: 160
-  gofumpt:
-    extra-rules: true
-  gosec:
-    excludes:
-      - G101
-      - G402
-  tagliatelle:
-    case:
-      use-field-name: true
-      rules:
-        json: pascal
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      extra-rules: true
+  exclusions:
+    generated: lax
 
 linters:
-  enable-all: true
+  default: all
   disable:
     - gocyclo # duplicate of cyclop
-    - tenv # deprecated
     - depguard
     - dupl
     - err113
@@ -35,19 +28,28 @@ linters:
     - gochecknoglobals
     - gochecknoinits
     - godox
-    - mnd
     - gomoddirectives
     - ireturn
     - lll
+    - mnd
     - nlreturn
     - nonamedreturns
     - tagliatelle
     - varnamelen
     - wrapcheck
     - wsl
-
-issues:
-  exclude-use-default: false
-  exclude:
-    - "ST1000: at least one file in a package should have a package comment"
-    - "package-comments: should have a package comment"
+  settings:
+    cyclop:
+      max-complexity: 15
+    lll:
+      line-length: 160
+  exclusions:
+    generated: lax
+    rules:
+      - path: (.+)\.go$
+        text: 'ST1000: at least one file in a package should have a package comment'
+      - path: (.+)\.go$
+        text: 'package-comments: should have a package comment'
+      - linters:
+          - cyclop
+        path: (.+)_test\.go


### PR DESCRIPTION
## Goal of this PR

This bumps golangci-lint to v2.1.6

## How did I test it?

<!-- A brief description the steps taken to test this pull request. -->
