### PR TITLE
chore: bump core to v0.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.4
 require (
 	github.com/ettle/strcase v0.2.0
 	github.com/gamefabric/gf-apicore v1.6.3
-	github.com/gamefabric/gf-core v0.24.1-0.20250624072451-56a834f0f2fb
+	github.com/gamefabric/gf-core v0.25.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/nitrado/tfconv v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/fxamacker/cbor/v2 v2.8.0 h1:fFtUGXUzXPHTIUdne5+zzMPTfffl3RD5qYnkY40vt
 github.com/fxamacker/cbor/v2 v2.8.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gamefabric/gf-apicore v1.6.3 h1:nuJyPem8v7cTWkFaPiSLeuwqMyh5GolUnEUzGH45TRw=
 github.com/gamefabric/gf-apicore v1.6.3/go.mod h1:7ckFjFXu2YBTipjLzgs36BMkH0atAaTclQX5Ei0G0F8=
-github.com/gamefabric/gf-core v0.24.1-0.20250624072451-56a834f0f2fb h1:rFgy4N9RssBfWegqqbiEXqm/DrzPKkroqOlLjG7et9g=
-github.com/gamefabric/gf-core v0.24.1-0.20250624072451-56a834f0f2fb/go.mod h1:frTbKoVJwEN+VMgV/X8WjKZJU8dCBapz8UGoCqsKz1c=
+github.com/gamefabric/gf-core v0.25.0 h1:W+8vp9nGN1vdU1umTtStM8gCPtnMHDqTLyVuftcJW/U=
+github.com/gamefabric/gf-core v0.25.0/go.mod h1:frTbKoVJwEN+VMgV/X8WjKZJU8dCBapz8UGoCqsKz1c=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
 github.com/go-git/go-billy/v5 v5.6.2 h1:6Q86EsPXMa7c3YZ3aLAQsMA0VlWmy43r6FHqa/UNbRM=


### PR DESCRIPTION
## Goal of this PR

This bumps core to v0.25.0

## How did I test it?

<!-- A brief description the steps taken to test this pull request. -->
